### PR TITLE
Add pen support

### DIFF
--- a/src/resources/assets/js/annotations/components/annotationCanvas/drawInteractions.js
+++ b/src/resources/assets/js/annotations/components/annotationCanvas/drawInteractions.js
@@ -3,6 +3,24 @@
  *
  * @type {Object}
  */
+
+/**
+ *
+ * Return `true` if the event originates from a digital pen or the shift key is pressed.
+ *
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
+ * @return {boolean} True if the event originates from a digital pen or the shift key
+ *         is pressed.
+ * @api
+ *
+ */
+const penOrShift = function(mapBrowserEvent) {
+  const pointerEvt =
+    /** @type {import("../MapBrowserPointerEvent").default} */ (mapBrowserEvent).pointerEvent;
+  // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
+  return pointerEvt.pointerType === "pen" || pointerEvt.shiftKey;
+};
+
 biigle.$component('annotations.components.annotationCanvas.drawInteractions', function () {
     var drawInteraction;
 
@@ -69,6 +87,7 @@ biigle.$component('annotations.components.annotationCanvas.drawInteractions', fu
                         source: this.annotationSource,
                         type: mode.slice(4), // remove 'draw' prefix
                         style: this.styles.editing,
+                        freehandCondition: penOrShift
                     });
                     drawInteraction.on('drawend', this.handleNewFeature);
                     this.map.addInteraction(drawInteraction);

--- a/src/resources/assets/js/annotations/components/annotationCanvas/drawInteractions.js
+++ b/src/resources/assets/js/annotations/components/annotationCanvas/drawInteractions.js
@@ -4,25 +4,13 @@
  * @type {Object}
  */
 
-/**
- *
- * Return `true` if the event originates from a digital pen or the shift key is pressed.
- *
- * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
- * @return {boolean} True if the event originates from a digital pen or the shift key
- *         is pressed.
- * @api
- *
- */
-const penOrShift = function(mapBrowserEvent) {
-  const pointerEvt =
-    /** @type {import("../MapBrowserPointerEvent").default} */ (mapBrowserEvent).pointerEvent;
-  // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
-  return pointerEvt.pointerType === "pen" || pointerEvt.shiftKey;
-};
-
 biigle.$component('annotations.components.annotationCanvas.drawInteractions', function () {
     var drawInteraction;
+
+    var penOrShift = function(mapBrowserEvent) {
+      var pointerEvt = (mapBrowserEvent).pointerEvent;
+      return pointerEvt.pointerType === "pen" || pointerEvt.shiftKey;
+    };
 
     return {
         computed: {


### PR DESCRIPTION
If a pen is used, in polygon drawing mode the freehand mode
is immediately activated. If a mouse is used, holding the shift key
pressed activates the freehand mode.